### PR TITLE
Add simp-expr

### DIFF
--- a/include/mukyu/cablin/expr/factory.hpp
+++ b/include/mukyu/cablin/expr/factory.hpp
@@ -12,6 +12,10 @@ namespace expr {
 mukyu::cablin::core::ExprPtr createExpr(
     const mukyu::cablin::core::ConfigPtr& node);
 
+// createSimpleExpr only allow operator/const/var expression
+mukyu::cablin::core::ExprPtr createSimpleExpr(
+    const mukyu::cablin::core::ConfigPtr& node);
+
 
 }  // namespace expr
 }  // namespace cablin

--- a/src/command/call.cpp
+++ b/src/command/call.cpp
@@ -25,7 +25,7 @@ public:
             auto size = paramsNode->size();
             for (size_t i = 0; i < size; ++i) {
                 auto item = paramsNode->at(i);
-                params_.push_back(mcexpr::createExpr(item));
+                params_.push_back(mcexpr::createSimpleExpr(item));
             }
         }
 

--- a/src/expr/binary_op.cpp
+++ b/src/expr/binary_op.cpp
@@ -18,8 +18,8 @@ class ExprBinaryOperator::Impl {
 public:
     Impl(const std::string& name, const mccore::ConfigPtr& node)
         : func_(FUNCTION_BINARY_OPERATOR_FUNC_MAP.at(name)),
-          expr1_(createExpr(node->at(0))),
-          expr2_(createExpr(node->at(1))) {
+          expr1_(createSimpleExpr(node->at(0))),
+          expr2_(createSimpleExpr(node->at(1))) {
     }
 
     ~Impl() = default;

--- a/src/expr/unary_op.cpp
+++ b/src/expr/unary_op.cpp
@@ -17,7 +17,7 @@ namespace mccore = mukyu::cablin::core;
 class ExprUnaryOperator::Impl {
 public:
     Impl(const std::string& name, const mccore::ConfigPtr& node)
-        : expr_(createExpr(node)),
+        : expr_(createSimpleExpr(node)),
           func_(FUNCTION_UNARY_OPERATOR_FUNC_MAP.at(name)) {
     }
 


### PR DESCRIPTION
In order to keep UI simple, we adjust:
Simple Expr only can be const or variable or unary/binary operator and
Only assignment can use full expr (i.e. original expr)